### PR TITLE
hotfix: change flat version

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "redux": "^4.0.5",
     "redux-api-middleware": "^3.2.1",
     "rollup": "^2.10.0",
-    "flat": "^6.0.1"
+    "flat": "^5.0.2"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Flat version 6 requires node >= 18. Version 5 works fine with node 16