### PR TITLE
flat-hotfix

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "build": "rollup -c",
     "start": "rollup -c -w",
-    "prepare":"npm run build"
+    "prepare": "npm run build"
   },
   "peerDependency": {
     "react-intl": "^5.8.1"
@@ -43,5 +43,7 @@
   "files": [
     "dist"
   ],
-  "dependencies": {}
+  "dependencies": {
+    "flat": "^5.0.2"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -37,8 +37,7 @@
     "react-router-dom": "^5.2.0",
     "redux": "^4.0.5",
     "redux-api-middleware": "^3.2.1",
-    "rollup": "^2.10.0",
-    "flat": "^6.0.1"
+    "rollup": "^2.10.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
Fixes error: Attempted import error: 'flat' does not contain a default export (imported as 'flatten').